### PR TITLE
Initialize Cat Facts Flask project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environment
+venv/
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# PyCharm
+.idea/
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-test
+# Cat Facts Flask App
+
+This project is a simple Flask application that displays a random cat fact. It follows common Flask conventions and keeps the code organized and easy to understand.
+
+## Setup
+
+1. **Create and activate a virtual environment**
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+2. **Install dependencies**
+
+```bash
+pip install -r requirements.txt
+```
+
+3. **Run the development server**
+
+```bash
+python app.py
+```
+
+Navigate to `http://localhost:5000` to view a random cat fact.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+
+def create_app():
+    app = Flask(__name__)
+
+    from .routes import main_bp
+    app.register_blueprint(main_bp)
+
+    return app

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,13 @@
+from flask import Blueprint, render_template
+import requests
+
+main_bp = Blueprint('main', __name__)
+
+
+@main_bp.route('/')
+def index():
+    """Display a random cat fact."""
+    response = requests.get('https://catfact.ninja/fact', timeout=5)
+    data = response.json()
+    fact = data.get('fact', 'No fact available.')
+    return render_template('index.html', fact=fact)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Cat Facts{% endblock %}</title>
+</head>
+<body>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block title %}Cat Facts{% endblock %}
+
+{% block content %}
+<h1>Random Cat Fact</h1>
+<p>{{ fact }}</p>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+blinker==1.9.0
+certifi==2025.6.15
+charset-normalizer==3.4.2
+click==8.2.1
+Flask==3.1.1
+idna==3.10
+itsdangerous==2.2.0
+Jinja2==3.1.6
+MarkupSafe==3.0.2
+requests==2.32.4
+urllib3==2.4.0
+Werkzeug==3.1.3


### PR DESCRIPTION
## Summary
- initialize basic Flask project
- add blueprint with route to fetch cat facts
- add minimal templates
- document setup and running in README
- track virtual environment files in .gitignore

## Testing
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_6851874002fc83208cb89bbdb6d544fa