### PR TITLE
Switch to turtle facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Cat Facts Flask App
+# Turtle Facts Flask App
 
-This project is a simple Flask application that displays a random cat fact. It follows common Flask conventions and keeps the code organized and easy to understand. Facts and images are retrieved from public APIs at runtime.
+This project is a simple Flask application that displays a random turtle fact. It follows common Flask conventions and keeps the code organized and easy to understand. Facts and images are retrieved from public APIs at runtime.
 
 ## Features
 
-- **Random cat facts** – The homepage loads with a unique fact every time, pulled from [catfact.ninja](https://catfact.ninja/fact).
-- **New fact on demand** – A button allows users to fetch another cat fact without refreshing the page.
-- **Cat images** – Each fact is paired with a random cat photo from the [Cataas](https://cataas.com/) API.
+- **Random turtle facts** – The homepage loads with a unique fact every time, pulled from a [GitHub dataset](https://raw.githubusercontent.com/Val7498/Turtle-facts-json/master/facts.json).
+- **New fact on demand** – A button allows users to fetch another turtle fact without refreshing the page.
+- **Turtle images** – Each fact is paired with a random turtle emoji from the [Twemoji](https://github.com/twitter/twemoji) or [OpenMoji](https://github.com/hfg-gmuend/openmoji) projects.
 - **Clean, responsive layout** – The site uses a modern design that works well on both desktop and mobile.
-- **Minimal setup** – Run locally with a single command to explore cat trivia.
+- **Minimal setup** – Run locally with a single command to explore turtle trivia.
 
 ## Setup
 
@@ -31,4 +31,4 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Navigate to `http://localhost:5000` to view a random cat fact.
+Navigate to `http://localhost:5000` to view a random turtle fact.

--- a/app/routes.py
+++ b/app/routes.py
@@ -7,7 +7,7 @@ main_bp = Blueprint('main', __name__)
 
 @main_bp.route('/')
 def index():
-    """Display the homepage with a random cat fact and image."""
+    """Display the homepage with a random turtle fact and image."""
     fact = get_random_fact()
     image = get_random_image()
     return render_template('index.html', fact=fact, image=image)
@@ -15,7 +15,7 @@ def index():
 
 @main_bp.route('/fact')
 def fact():
-    """Return a new random cat fact and image as JSON."""
+    """Return a new random turtle fact and image as JSON."""
     data = {
         'fact': get_random_fact(),
         'image': get_random_image(),

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>{% block title %}Cat Facts{% endblock %}</title>
+    <title>{% block title %}Turtle Facts{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,15 +1,15 @@
 {% extends 'base.html' %}
 
-{% block title %}Cat Facts{% endblock %}
+{% block title %}Turtle Facts{% endblock %}
 
 {% block content %}
 <div class="card text-center">
   <div class="card-body">
-    <h1 class="card-title mb-3">Random Cat Fact</h1>
+    <h1 class="card-title mb-3">Random Turtle Fact</h1>
     <div id="image-container" class="mb-3">
-      <img id="cat-image" src="{{ image }}" alt="Cute cat" class="img-fluid" />
+      <img id="turtle-image" src="{{ image }}" alt="Turtle" class="img-fluid" />
     </div>
-    <p id="cat-fact" class="card-text">{{ fact }}</p>
+    <p id="turtle-fact" class="card-text">{{ fact }}</p>
     <div id="loading" class="spinner-border text-primary my-3 d-none" role="status">
       <span class="visually-hidden">Loading...</span>
     </div>
@@ -27,8 +27,8 @@ button.addEventListener('click', function() {
   fetch('{{ url_for('main.fact') }}')
     .then(response => response.json())
     .then(data => {
-      document.getElementById('cat-fact').innerText = data.fact;
-      document.getElementById('cat-image').src = data.image;
+      document.getElementById('turtle-fact').innerText = data.fact;
+      document.getElementById('turtle-image').src = data.image;
     })
     .catch(err => console.error('Error fetching fact:', err))
     .finally(() => {

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,9 +1,13 @@
 import requests
 import time
+import random
 
 
-FACT_URL = "https://catfact.ninja/fact"
-CATAAS_URL = "https://cataas.com/cat"
+FACT_URL = "https://raw.githubusercontent.com/Val7498/Turtle-facts-json/master/facts.json"
+IMAGE_URLS = [
+    "https://raw.githubusercontent.com/twitter/twemoji/master/assets/72x72/1f422.png",
+    "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/1F422.png",
+]
 
 
 def _fetch_json(url: str, timeout: float = 5.0) -> dict:
@@ -17,12 +21,16 @@ def _fetch_json(url: str, timeout: float = 5.0) -> dict:
 
 
 def get_random_fact() -> str:
-    """Return a random cat fact from the API."""
+    """Return a random turtle fact from the API."""
     data = _fetch_json(FACT_URL)
-    return data.get("fact", "Could not load a cat fact right now.")
+    facts = data.get("JSON", {}).get("Facts", [])
+    if not facts:
+        return "Could not load a turtle fact right now."
+    return random.choice(facts)
 
 
 def get_random_image() -> str:
-    """Return a URL to a random cat image from the API."""
+    """Return a URL to a random turtle image."""
+    url = random.choice(IMAGE_URLS)
     timestamp = int(time.time())
-    return f"{CATAAS_URL}?{timestamp}"
+    return f"{url}?{timestamp}"


### PR DESCRIPTION
## Summary
- swap out cat info for turtle facts in the README
- update page titles and labels for turtles
- serve turtle facts from a GitHub dataset
- randomly pick a turtle emoji image instead of using Cataas

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68519366449c8320b62fecb2183bc21f